### PR TITLE
fix: resolve YAML parse error in codeberg.yml (heredoc indentation)

### DIFF
--- a/.github/workflows/codeberg.yml
+++ b/.github/workflows/codeberg.yml
@@ -72,13 +72,12 @@ jobs:
           git remote remove codeberg 2>/dev/null || true
           git remote add codeberg "https://codeberg.org/unwanted9855/blended-strawberry.git"
           # Use git credential store for the token so it never appears in remote URLs
-          echo "https://codeberg.org" > /tmp/codeberg-credentials
-          git credential-store --file /tmp/codeberg-credentials store <<EOF
-protocol=https
-host=codeberg.org
-username=${CODEBERG_TOKEN}
-password=${CODEBERG_TOKEN}
-EOF
+          {
+            echo "protocol=https"
+            echo "host=codeberg.org"
+            echo "username=${CODEBERG_TOKEN}"
+            echo "password=${CODEBERG_TOKEN}"
+          } | git credential-store --file /tmp/codeberg-credentials store
           git config --global credential.helper "store --file /tmp/codeberg-credentials"
 
           # Make sure local is on the TARGET branch (create/update as needed)


### PR DESCRIPTION
PR #27 introduced a credential-store heredoc inside the YAML literal block scalar, but the heredoc content lines (protocol=https, host=codeberg.org, username=..., password=..., EOF) were at column 0 - under-indented relative to the 10-space block scalar base indent. The YAML parser sees these as top-level nodes, causing a parse error.

**Fix:** Replaced the heredoc with a brace-enclosed group of echo commands piped to git credential-store store. All lines are now consistently indented, and the file parses correctly.